### PR TITLE
add hardwareinterface to joint in transmission tag

### DIFF
--- a/rrbot_description/urdf/rrbot.xacro
+++ b/rrbot_description/urdf/rrbot.xacro
@@ -184,7 +184,9 @@
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="joint1"/>
+    <joint name="joint1">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -193,7 +195,9 @@
 
   <transmission name="tran2">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="joint2"/>
+    <joint name="joint2">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor2">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>


### PR DESCRIPTION
- this is workaround for https://github.com/ros-controls/ros_control/issues/177
- see http://answers.ros.org/question/186681/no-valid-hardware-interface-element-found-in-joint/ for solution
- related discussion http://answers.gazebosim.org/question/6654/gazeboos-x-109-no-valid-hardware-interface-element/