### PR TITLE
Insert an optical frame so that rviz/Camera can correctly overlay

### DIFF
--- a/rrbot_control/launch/rrbot_control.launch
+++ b/rrbot_control/launch/rrbot_control.launch
@@ -15,7 +15,4 @@
     <remap from="/joint_states" to="/rrbot/joint_states" />
   </node>
 
-  <!-- Show in Rviz   -->
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rrbot_description)/launch/rrbot.rviz"/>
-
 </launch>

--- a/rrbot_control/launch/rrbot_control.launch
+++ b/rrbot_control/launch/rrbot_control.launch
@@ -15,4 +15,7 @@
     <remap from="/joint_states" to="/rrbot/joint_states" />
   </node>
 
+  <!-- Show in Rviz   -->
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rrbot_description)/launch/rrbot.rviz"/>
+
 </launch>

--- a/rrbot_description/urdf/rrbot.gazebo
+++ b/rrbot_description/urdf/rrbot.gazebo
@@ -104,7 +104,7 @@
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
         <frameName>camera_link_optical</frameName>
         <!-- setting hackBaseline to anything but 0.0 will cause a misalignment
-            between the gazebo sensor image and the frame it is supposed to 
+            between the gazebo sensor image and the frame it is supposed to
             be attached to -->
         <hackBaseline>0.0</hackBaseline>
         <distortionK1>0.0</distortionK1>

--- a/rrbot_description/urdf/rrbot.gazebo
+++ b/rrbot_description/urdf/rrbot.gazebo
@@ -102,8 +102,11 @@
         <cameraName>rrbot/camera1</cameraName>
         <imageTopicName>image_raw</imageTopicName>
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-        <frameName>camera_link</frameName>
-        <hackBaseline>0.07</hackBaseline>
+        <frameName>camera_link_optical</frameName>
+        <!-- setting hackBaseline to anything but 0.0 will cause a misalignment
+            between the gazebo sensor image and the frame it is supposed to 
+            be attached to -->
+        <hackBaseline>0.0</hackBaseline>
         <distortionK1>0.0</distortionK1>
         <distortionK2>0.0</distortionK2>
         <distortionK3>0.0</distortionK3>

--- a/rrbot_description/urdf/rrbot.xacro
+++ b/rrbot_description/urdf/rrbot.xacro
@@ -183,6 +183,19 @@
     </inertial>
   </link>
 
+  <!-- generate an optical frame http://www.ros.org/reps/rep-0103.html#suffix-frames
+      so that ros and opencv can operate on the camera frame correctly -->
+  <joint name="camera_optical_joint" type="fixed">
+    <!-- these values have to be these values otherwise the gazebo camera image
+        won't be aligned properly with the frame it is supposedly originating from -->
+    <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+    <parent link="camera_link"/>
+    <child link="camera_link_optical"/>
+  </joint>
+
+  <link name="camera_link_optical">
+  </link>
+
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="joint1">


### PR DESCRIPTION
Insert an optical frame so that rviz/Camera can correctly on top of the camera image.  Also zero out hackBaseline so that there isn't an offset between the gazebo image and the rviz overlay.  This follows from https://github.com/ros-simulation/gazebo_ros_pkgs/issues/424

In separate terminals:

```
roslaunch rrbot_gazebo rrbot_world.launch
roslaunch rrbot_control rrbot_control.launch
rostopic pub /rrbot/joint2_position_controller/command std_msgs/Float64 "data: -0.9"
```

I made rrbot_control.launch launch rviz, I think if it is launching rviz then it is less likely this will get fouled up in the future.  A test could be devised but I think it would have to involve whole image pixel comparisons with stored images.

The joint command should make the arm visible in the camera view, and when that is done it is possible to look for discrepancies between the rviz generate robotmodel and the gazebo generated image of the arm.  If hackBaseline is non-zero then there will be a ghost arm slightly offset from the other arm, or if the optical frame were wrong the rviz/Camera image could be pointed anywhere else at all.  

This shows the correctly overlaying robotmodel on the gazebo image: http://answers.ros.org/upfiles/1461298601930351.png

It might be nice if the gazebo camera plugin could generate the right frame and it wasn't up to the user to create it in xacro, but at least having a good example of doing it manually in this repository will reduce confusion- I made https://github.com/ros-simulation/gazebo_ros_pkgs/issues/424 with changing the plugin in mind.
