### PR TITLE
changed the depreceated node type 'state_publisher'

### DIFF
--- a/rrbot_description/launch/rrbot_rviz.launch
+++ b/rrbot_description/launch/rrbot_rviz.launch
@@ -8,7 +8,7 @@
   </node>
 
   <!-- Combine joint values -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   <!-- Show in Rviz   -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rrbot_description)/launch/rrbot.rviz"/>


### PR DESCRIPTION
Fixed issue:
When using `roslaunch rrbot_description rrbot_rviz.launch`,It warns 
```
[WARN] [1597821207.287022]: Controller Spawner couldn't find the expected controller_manager ROS interface 
```
- [x] Fixed unable to find controller for noetic devel
- [ ] create new branch or noetic and merge this request 