### PR TITLE
Update rrbot_rviz.launch

### DIFF
--- a/rrbot_description/launch/rrbot_rviz.launch
+++ b/rrbot_description/launch/rrbot_rviz.launch
@@ -8,7 +8,7 @@
   </node>
 
   <!-- Combine joint values -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   <!-- Show in Rviz   -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rrbot_description)/launch/rrbot.rviz"/>


### PR DESCRIPTION
Launching RRBot in RViz resulted in transform errors in the model. Correcting the robot_state_publisher type fixes this issue.